### PR TITLE
Make Passthrough exporter work with non-square sources

### DIFF
--- a/csv_wrangler/test_exporter.py
+++ b/csv_wrangler/test_exporter.py
@@ -123,3 +123,14 @@ class PassthroughExporterTestCase(TestCase):
         self.assertEqual(results[0], ['a', 'b', 'c'])
         self.assertEqual(results[1], ['1', '2', '3'])
         self.assertEqual(results[2], ['2', '3', '4'])
+
+    def test_malformed_passthrough(self) -> None:
+        exporter = PassthroughExporter([
+            ['a', 'b', 'c'],
+            [],
+            ['d', 'e', 'f'],
+        ])
+        results = exporter.to_list()
+        self.assertEqual(results[0], ['a', 'b', 'c'])
+        self.assertEqual(results[1], [])
+        self.assertEqual(results[2], ['d', 'e', 'f'])


### PR DESCRIPTION
Correct passthrough to ignore shape - passing through multiexporters should work through it.

This removes the ability to order on a Passthrough, but you probably shouldn't be doing it there anyways as it IS a passthrough.