### PR TITLE
Allow getting the content as a CSV

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class LlamaCsvExportView(View):
         return exporter.as_response(filename='my_llamas')
 ```
 
-If you don't want to deal with any further CSV parsing, and just want to get the finished CSV as a string, use the `as_string` method.
+If you don't want to deal with any further CSV parsing, and just want to get the finished CSV as a string, use the `as_string` method. If you need to send the string as a response, it's likely more optimal to use the `as_response` or `as_streamed_response` methods.
 
 When you want to setup and endpoint for getting the csv, this'll be as simple as adding the following to `urls.py`
 

--- a/README.md
+++ b/README.md
@@ -121,6 +121,8 @@ class LlamaCsvExportView(View):
         return exporter.as_response(filename='my_llamas')
 ```
 
+If you don't want to deal with any further CSV parsing, and just want to get the finished CSV as a string, use the `as_csv` method.
+
 When you want to setup and endpoint for getting the csv, this'll be as simple as adding the following to `urls.py`
 
 ```python

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ class LlamaCsvExportView(View):
         return exporter.as_response(filename='my_llamas')
 ```
 
-If you don't want to deal with any further CSV parsing, and just want to get the finished CSV as a string, use the `as_csv` method.
+If you don't want to deal with any further CSV parsing, and just want to get the finished CSV as a string, use the `as_string` method.
 
 When you want to setup and endpoint for getting the csv, this'll be as simple as adding the following to `urls.py`
 

--- a/csv_wrangler/exporter.py
+++ b/csv_wrangler/exporter.py
@@ -48,14 +48,14 @@ class BaseExporter(metaclass=ABCMeta):
     def format_content_disposition(self, filename: str='export') -> str:
         return 'attachment; filename="{}.csv"'.format(filename)
 
-    def as_csv(self) -> str:
+    def as_string(self) -> str:
         buffer = StringIO()
         writer = csv.writer(buffer)
         writer.writerows(self.to_iter())
         return buffer.getvalue()
 
     def as_response(self, filename: str) -> HttpResponse:
-        response = HttpResponse(content=self.as_csv().encode(), content_type=self.CONTENT_TYPE)
+        response = HttpResponse(content=self.as_string().encode(), content_type=self.CONTENT_TYPE)
         response['Content-Disposition'] = self.format_content_disposition(filename)
         return response
 

--- a/csv_wrangler/test_exporter.py
+++ b/csv_wrangler/test_exporter.py
@@ -3,6 +3,7 @@ from typing import NamedTuple
 from typing import List, Any
 from csv_wrangler.exporter import Exporter, Header, MultiExporter, SimpleExporter, PassthroughExporter
 from django.http import StreamingHttpResponse, HttpResponse
+from textwrap import dedent
 
 
 DummyData = NamedTuple('DummyData', [('a', str), ('b', int), ('c', float)])
@@ -98,6 +99,15 @@ class ExporterTestCase(TestCase):
             for row
             in self.exporter.to_list()
         ]) + '\r\n')
+
+    def test_as_csv(self) -> None:
+        data = self.exporter.as_csv()
+        self.assertEqual(data, dedent("""
+            a,b,c
+            a,1,1.0
+            b,2,2.0
+            c,3,3.0
+        """).replace("\n", "\r\n").lstrip())
 
 
 class MultiExporterTestCase(TestCase):

--- a/csv_wrangler/test_exporter.py
+++ b/csv_wrangler/test_exporter.py
@@ -100,8 +100,8 @@ class ExporterTestCase(TestCase):
             in self.exporter.to_list()
         ]) + '\r\n')
 
-    def test_as_csv(self) -> None:
-        data = self.exporter.as_csv()
+    def test_as_string(self) -> None:
+        data = self.exporter.as_string()
         self.assertEqual(data, dedent("""
             a,b,c
             a,1,1.0


### PR DESCRIPTION
Seems like quite a large omission, but previously you had to manually generate the underlying CSV string if you needed it in memory, rather than returned as a response! 