### PR TITLE
Update version requirements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
 - "3.6"
 - "3.7"
 env:
-- DJANGO_VERSION=1.8
 - DJANGO_VERSION=1.11
 - DJANGO_VERSION=2.2
 install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ python:
 - "3.4"
 - "3.5"
 - "3.6"
+- "3.7"
 env:
 - DJANGO_VERSION=1.8
 - DJANGO_VERSION=1.11
+- DJANGO_VERSION=2.2
 install:
 - pip install -r test-requirements.txt
 - pip install -U django~=$DJANGO_VERSION

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ author = 'DabApps'
 author_email = 'engineering@dabapps.com'
 license = 'BSD'
 install_requires = [
-    "Django>=1.8",
+    "Django>=1.11",
 ]
 
 long_description = """Statically-typed Python 3 CSV generation helpers.


### PR DESCRIPTION
This PR drops support for Django 1.8, and ensures we're testing against Django 2.2.