### PR TITLE
allow specifying charset

### DIFF
--- a/csv_wrangler/exporter.py
+++ b/csv_wrangler/exporter.py
@@ -55,16 +55,20 @@ class BaseExporter(metaclass=ABCMeta):
     def format_content_disposition(self, filename: str='export') -> str:
         return 'attachment; filename="{}.csv"'.format(filename)
 
-    def as_response(self, filename: str) -> HttpResponse:
-        response = HttpResponse(content_type=self.CONTENT_TYPE)
+    def as_response(self, filename: str, charset: str = 'utf-8') -> HttpResponse:
+        response = HttpResponse(
+            content_type=self.CONTENT_TYPE,
+            charset=charset
+        )
         response['Content-Disposition'] = self.format_content_disposition(filename)
         self.dump(response)
         return response
 
-    def as_streamed_response(self, filename: str) -> StreamingHttpResponse:
+    def as_streamed_response(self, filename: str, charset: str = 'utf-8') -> StreamingHttpResponse:
         response = StreamingHttpResponse(
             self.as_csv_rows(),
-            content_type=self.CONTENT_TYPE
+            content_type=self.CONTENT_TYPE,
+            charset=charset
         )
         response['Content-Disposition'] = self.format_content_disposition(filename)
         return response

--- a/csv_wrangler/test_exporter.py
+++ b/csv_wrangler/test_exporter.py
@@ -94,7 +94,7 @@ class ExporterTestCase(TestCase):
         results = self.exporter.as_response(filename, charset='cp1252')
         self.assertIsInstance(results, HttpResponse)
         self.assertEqual(results['content-type'], 'text/csv')
-        self.assertEqual(results['Content-Disposition'], f'attachment; filename="{filename}.csv"')
+        self.assertEqual(results['Content-Disposition'], 'attachment; filename="{}.csv"'.format(filename))
         self.assertEqual(str(results.content, 'cp1252'), '\r\n'.join([
             ','.join(row)
             for row
@@ -106,7 +106,7 @@ class ExporterTestCase(TestCase):
         results = self.exporter.as_streamed_response(filename)
         self.assertIsInstance(results, StreamingHttpResponse)
         self.assertEqual(results['content-type'], 'text/csv')
-        self.assertEqual(results['Content-Disposition'], f'attachment; filename="{filename}.csv"')
+        self.assertEqual(results['Content-Disposition'], 'attachment; filename="{}.csv"'.format(filename))
         self.assertEqual(results.getvalue().decode(), '\r\n'.join([
             ','.join(row)
             for row
@@ -118,7 +118,7 @@ class ExporterTestCase(TestCase):
         results = self.exporter.as_streamed_response(filename, charset='cp1252')
         self.assertIsInstance(results, StreamingHttpResponse)
         self.assertEqual(results['content-type'], 'text/csv')
-        self.assertEqual(results['Content-Disposition'], f'attachment; filename="{filename}.csv"')
+        self.assertEqual(results['Content-Disposition'], 'attachment; filename="{}.csv"'.format(filename))
         self.assertEqual(results.getvalue().decode(), '\r\n'.join([
             ','.join(row)
             for row

--- a/csv_wrangler/test_exporter.py
+++ b/csv_wrangler/test_exporter.py
@@ -89,12 +89,36 @@ class ExporterTestCase(TestCase):
             in self.exporter.to_list()
         ]) + '\r\n')
 
+    def test_as_response_with_charset(self) -> None:
+        filename = 'hello'
+        results = self.exporter.as_response(filename, charset='cp1252')
+        self.assertIsInstance(results, HttpResponse)
+        self.assertEqual(results['content-type'], 'text/csv')
+        self.assertEqual(results['Content-Disposition'], f'attachment; filename="{filename}.csv"')
+        self.assertEqual(str(results.content, 'cp1252'), '\r\n'.join([
+            ','.join(row)
+            for row
+            in self.exporter.to_list()
+        ]) + '\r\n')
+
     def test_as_streamed_response(self) -> None:
         filename = 'hello'
         results = self.exporter.as_streamed_response(filename)
         self.assertIsInstance(results, StreamingHttpResponse)
         self.assertEqual(results['content-type'], 'text/csv')
-        self.assertEqual(results['Content-Disposition'], 'attachment; filename="hello.csv"')
+        self.assertEqual(results['Content-Disposition'], f'attachment; filename="{filename}.csv"')
+        self.assertEqual(results.getvalue().decode(), '\r\n'.join([
+            ','.join(row)
+            for row
+            in self.exporter.to_list()
+        ]) + '\r\n')
+
+    def test_as_streamed_response_with_charset(self) -> None:
+        filename = 'hello'
+        results = self.exporter.as_streamed_response(filename, charset='cp1252')
+        self.assertIsInstance(results, StreamingHttpResponse)
+        self.assertEqual(results['content-type'], 'text/csv')
+        self.assertEqual(results['Content-Disposition'], f'attachment; filename="{filename}.csv"')
         self.assertEqual(results.getvalue().decode(), '\r\n'.join([
             ','.join(row)
             for row


### PR DESCRIPTION
 ### Problem
On a client project we have users using languages other than English and are using characters such as à and ê which are being incorrectly displayed on csv exports when using excel. Excel nativly opens a csv file using ansi (`cp1252`) encoding which has different codes for these characters so they are being mis-read. To solve this I have identified that if a csv is encoded in the native windows ansi format both macs and excel on windows natively open read the files correctly without the need for manual conversion each time.

### Change
I have added an optional parameter `charset` to the `as_response` and `as_streamed_response` methods which allows you to supply a charset for encoding if you would like something other than `utf-8`